### PR TITLE
Pass all parentIDs to Unpack

### DIFF
--- a/create_test.go
+++ b/create_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Create", func() {
 
 		BeforeEach(func() {
 			rootfsFileBuffer = bytes.NewBuffer([]byte{})
-			driver.UnpackStub = func(logger lager.Logger, id, parentID string, layerTar io.Reader) error {
+			driver.UnpackStub = func(logger lager.Logger, id string, parentIDs []string, layerTar io.Reader) error {
 				_, err := io.Copy(rootfsFileBuffer, layerTar)
 				Expect(err).NotTo(HaveOccurred())
 				return nil

--- a/groot.go
+++ b/groot.go
@@ -21,7 +21,7 @@ import (
 // Driver should implement the filesystem interaction
 //go:generate counterfeiter . Driver
 type Driver interface {
-	Unpack(logger lager.Logger, layerID, parentID string, layerTar io.Reader) error
+	Unpack(logger lager.Logger, layerID string, parentIDs []string, layerTar io.Reader) error
 	Bundle(logger lager.Logger, bundleID string, layerIDs []string) (runspec.Spec, error)
 	Exists(logger lager.Logger, layerID string) bool
 	Delete(logger lager.Logger, bundleID string) error

--- a/grootfakes/fake_driver.go
+++ b/grootfakes/fake_driver.go
@@ -11,13 +11,13 @@ import (
 )
 
 type FakeDriver struct {
-	UnpackStub        func(logger lager.Logger, layerID, parentID string, layerTar io.Reader) error
+	UnpackStub        func(logger lager.Logger, layerID string, parentIDs []string, layerTar io.Reader) error
 	unpackMutex       sync.RWMutex
 	unpackArgsForCall []struct {
-		logger   lager.Logger
-		layerID  string
-		parentID string
-		layerTar io.Reader
+		logger    lager.Logger
+		layerID   string
+		parentIDs []string
+		layerTar  io.Reader
 	}
 	unpackReturns struct {
 		result1 error
@@ -68,19 +68,24 @@ type FakeDriver struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeDriver) Unpack(logger lager.Logger, layerID string, parentID string, layerTar io.Reader) error {
+func (fake *FakeDriver) Unpack(logger lager.Logger, layerID string, parentIDs []string, layerTar io.Reader) error {
+	var parentIDsCopy []string
+	if parentIDs != nil {
+		parentIDsCopy = make([]string, len(parentIDs))
+		copy(parentIDsCopy, parentIDs)
+	}
 	fake.unpackMutex.Lock()
 	ret, specificReturn := fake.unpackReturnsOnCall[len(fake.unpackArgsForCall)]
 	fake.unpackArgsForCall = append(fake.unpackArgsForCall, struct {
-		logger   lager.Logger
-		layerID  string
-		parentID string
-		layerTar io.Reader
-	}{logger, layerID, parentID, layerTar})
-	fake.recordInvocation("Unpack", []interface{}{logger, layerID, parentID, layerTar})
+		logger    lager.Logger
+		layerID   string
+		parentIDs []string
+		layerTar  io.Reader
+	}{logger, layerID, parentIDsCopy, layerTar})
+	fake.recordInvocation("Unpack", []interface{}{logger, layerID, parentIDsCopy, layerTar})
 	fake.unpackMutex.Unlock()
 	if fake.UnpackStub != nil {
-		return fake.UnpackStub(logger, layerID, parentID, layerTar)
+		return fake.UnpackStub(logger, layerID, parentIDs, layerTar)
 	}
 	if specificReturn {
 		return ret.result1
@@ -94,10 +99,10 @@ func (fake *FakeDriver) UnpackCallCount() int {
 	return len(fake.unpackArgsForCall)
 }
 
-func (fake *FakeDriver) UnpackArgsForCall(i int) (lager.Logger, string, string, io.Reader) {
+func (fake *FakeDriver) UnpackArgsForCall(i int) (lager.Logger, string, []string, io.Reader) {
 	fake.unpackMutex.RLock()
 	defer fake.unpackMutex.RUnlock()
-	return fake.unpackArgsForCall[i].logger, fake.unpackArgsForCall[i].layerID, fake.unpackArgsForCall[i].parentID, fake.unpackArgsForCall[i].layerTar
+	return fake.unpackArgsForCall[i].logger, fake.unpackArgsForCall[i].layerID, fake.unpackArgsForCall[i].parentIDs, fake.unpackArgsForCall[i].layerTar
 }
 
 func (fake *FakeDriver) UnpackReturns(result1 error) {

--- a/imagepuller/image_puller.go
+++ b/imagepuller/image_puller.go
@@ -37,7 +37,7 @@ type Fetcher interface {
 }
 
 type VolumeDriver interface {
-	Unpack(logger lager.Logger, layerID, parentID string, layerTar io.Reader) error
+	Unpack(logger lager.Logger, layerID string, parentIDs []string, layerTar io.Reader) error
 	Exists(logger lager.Logger, layerID string) bool
 }
 
@@ -150,12 +150,14 @@ func (p *ImagePuller) buildLayer(logger lager.Logger, index int, layerInfos []La
 
 	defer downloadResult.Stream.Close()
 
-	parentChainID := ""
+	parentChainIDs := []string{}
 	if index != 0 {
-		parentChainID = layerInfos[index-1].ChainID
+		for i := 0; i < index; i++ {
+			parentChainIDs = append(parentChainIDs, layerInfos[i].ChainID)
+		}
 	}
 
-	return p.volumeDriver.Unpack(logger, layerInfos[index].ChainID, parentChainID, downloadResult.Stream)
+	return p.volumeDriver.Unpack(logger, layerInfos[index].ChainID, parentChainIDs, downloadResult.Stream)
 }
 
 type downloadReturn struct {

--- a/imagepuller/imagepullerfakes/fake_volume_driver.go
+++ b/imagepuller/imagepullerfakes/fake_volume_driver.go
@@ -10,12 +10,12 @@ import (
 )
 
 type FakeVolumeDriver struct {
-	UnpackStub        func(logger lager.Logger, layerID, parentID string, layerTar io.Reader) error
+	UnpackStub        func(logger lager.Logger, layerID string, parentID []string, layerTar io.Reader) error
 	unpackMutex       sync.RWMutex
 	unpackArgsForCall []struct {
 		logger   lager.Logger
 		layerID  string
-		parentID string
+		parentID []string
 		layerTar io.Reader
 	}
 	unpackReturns struct {
@@ -40,16 +40,21 @@ type FakeVolumeDriver struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeVolumeDriver) Unpack(logger lager.Logger, layerID string, parentID string, layerTar io.Reader) error {
+func (fake *FakeVolumeDriver) Unpack(logger lager.Logger, layerID string, parentID []string, layerTar io.Reader) error {
+	var parentIDCopy []string
+	if parentID != nil {
+		parentIDCopy = make([]string, len(parentID))
+		copy(parentIDCopy, parentID)
+	}
 	fake.unpackMutex.Lock()
 	ret, specificReturn := fake.unpackReturnsOnCall[len(fake.unpackArgsForCall)]
 	fake.unpackArgsForCall = append(fake.unpackArgsForCall, struct {
 		logger   lager.Logger
 		layerID  string
-		parentID string
+		parentID []string
 		layerTar io.Reader
-	}{logger, layerID, parentID, layerTar})
-	fake.recordInvocation("Unpack", []interface{}{logger, layerID, parentID, layerTar})
+	}{logger, layerID, parentIDCopy, layerTar})
+	fake.recordInvocation("Unpack", []interface{}{logger, layerID, parentIDCopy, layerTar})
 	fake.unpackMutex.Unlock()
 	if fake.UnpackStub != nil {
 		return fake.UnpackStub(logger, layerID, parentID, layerTar)
@@ -66,7 +71,7 @@ func (fake *FakeVolumeDriver) UnpackCallCount() int {
 	return len(fake.unpackArgsForCall)
 }
 
-func (fake *FakeVolumeDriver) UnpackArgsForCall(i int) (lager.Logger, string, string, io.Reader) {
+func (fake *FakeVolumeDriver) UnpackArgsForCall(i int) (lager.Logger, string, []string, io.Reader) {
 	fake.unpackMutex.RLock()
 	defer fake.unpackMutex.RUnlock()
 	return fake.unpackArgsForCall[i].logger, fake.unpackArgsForCall[i].layerID, fake.unpackArgsForCall[i].parentID, fake.unpackArgsForCall[i].layerTar

--- a/integration/cmd/toot/toot/toot.go
+++ b/integration/cmd/toot/toot/toot.go
@@ -16,7 +16,7 @@ type Toot struct {
 	BaseDir string
 }
 
-func (t *Toot) Unpack(logger lager.Logger, id, parentID string, layerTar io.Reader) error {
+func (t *Toot) Unpack(logger lager.Logger, id string, parentIDs []string, layerTar io.Reader) error {
 	logger.Info("unpack-info")
 	logger.Debug("unpack-debug")
 
@@ -27,7 +27,7 @@ func (t *Toot) Unpack(logger lager.Logger, id, parentID string, layerTar io.Read
 	layerTarContents, err := ioutil.ReadAll(layerTar)
 	must(err)
 	saveObject([]interface{}{
-		UnpackArgs{ID: id, ParentID: parentID, LayerTarContents: layerTarContents},
+		UnpackArgs{ID: id, ParentIDs: parentIDs, LayerTarContents: layerTarContents},
 	}, t.pathTo(UnpackArgsFileName))
 	return nil
 }
@@ -99,7 +99,7 @@ type DeleteArgs struct {
 type UnpackCalls []UnpackArgs
 type UnpackArgs struct {
 	ID               string
-	ParentID         string
+	ParentIDs        []string
 	LayerTarContents []byte
 }
 

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -76,7 +76,7 @@ var _ = Describe("groot", func() {
 				var args toot.UnpackCalls
 				readTestArgsFile(toot.UnpackArgsFileName, &args)
 				Expect(args[0].ID).NotTo(BeEmpty())
-				Expect(args[0].ParentID).To(BeEmpty())
+				Expect(args[0].ParentIDs).To(BeEmpty())
 			})
 
 			It("calls driver.Bundle() with expected args", func() {
@@ -301,6 +301,19 @@ var _ = Describe("groot", func() {
 				})
 
 				whenCreationSucceeds()
+
+				Context("when the image has multiple layers", func() {
+					It("correctly passes parent IDs to each driver.Unpack() call", func() {
+						var args toot.UnpackCalls
+						readTestArgsFile(toot.UnpackArgsFileName, &args)
+
+						chainIDs := []string{}
+						for _, a := range args {
+							Expect(a.ParentIDs).To(Equal(chainIDs))
+							chainIDs = append(chainIDs, a.ID)
+						}
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
Windows requires all parents of a layer in order to unpack it, we now pass a slice of layers (in order from oldest parent to newest) instead of just the immediate parent

**We made a PR instead of just pushing even though we have access, let us know if it makes sense for us to just push to this repo instead**