### PR TITLE
Add --exclude-image-from-quota and --disk-limit-size-bytes

### DIFF
--- a/create.go
+++ b/create.go
@@ -1,6 +1,7 @@
 package groot
 
 import (
+	"fmt"
 	"net/url"
 
 	"code.cloudfoundry.org/groot/imagepuller"
@@ -8,17 +9,36 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (g *Groot) Create(handle string, rootfsURI *url.URL) (runspec.Spec, error) {
+func (g *Groot) Create(handle string, rootfsURI *url.URL, diskLimit int64, excludeImageFromQuota bool) (runspec.Spec, error) {
 	g.Logger = g.Logger.Session("create")
 	g.Logger.Debug("starting")
 	defer g.Logger.Debug("ending")
 
-	image, err := g.ImagePuller.Pull(g.Logger, imagepuller.ImageSpec{ImageSrc: rootfsURI})
+	if diskLimit < 0 {
+		return runspec.Spec{}, fmt.Errorf("invalid disk limit: %d", diskLimit)
+	}
+
+	imageSpec := imagepuller.ImageSpec{
+		ImageSrc:              rootfsURI,
+		DiskLimit:             diskLimit,
+		ExcludeImageFromQuota: excludeImageFromQuota,
+	}
+
+	image, err := g.ImagePuller.Pull(g.Logger, imageSpec)
 	if err != nil {
 		return runspec.Spec{}, errors.Wrap(err, "pulling image")
 	}
 
-	bundle, err := g.Driver.Bundle(g.Logger.Session("bundle"), handle, image.ChainIDs)
+	quota := diskLimit
+
+	if diskLimit != 0 && !excludeImageFromQuota {
+		quota = quota - image.BaseImageSize
+		if quota <= 0 {
+			return runspec.Spec{}, fmt.Errorf("disk limit %d must be larger than image size %d", diskLimit, image.BaseImageSize)
+		}
+	}
+
+	bundle, err := g.Driver.Bundle(g.Logger.Session("bundle"), handle, image.ChainIDs, quota)
 	if err != nil {
 		return runspec.Spec{}, errors.Wrap(err, "creating bundle")
 	}

--- a/fetcher/filefetcher/file_fetcher.go
+++ b/fetcher/filefetcher/file_fetcher.go
@@ -64,6 +64,7 @@ func (l *FileFetcher) ImageInfo(logger lager.Logger, imageURL *url.URL) (imagepu
 				BlobID:        imageURL.String(),
 				ParentChainID: "",
 				ChainID:       l.generateChainID(imageURL.String(), stat.ModTime().UnixNano()),
+				Size:          stat.Size(),
 			},
 		},
 	}, nil

--- a/fetcher/filefetcher/file_fetcher_test.go
+++ b/fetcher/filefetcher/file_fetcher_test.go
@@ -97,6 +97,7 @@ var _ = Describe("File Fetcher", func() {
 			Expect(strings.EqualFold(layers[0].BlobID, imagePath)).To(BeTrue())
 			Expect(layers[0].ChainID).NotTo(BeEmpty())
 			Expect(layers[0].ParentChainID).To(BeEmpty())
+			Expect(layers[0].Size).To(Equal(int64(len("hello-world"))))
 
 			Expect(imageInfo.Config).To(Equal(v1.Image{}))
 		})

--- a/groot.go
+++ b/groot.go
@@ -22,7 +22,7 @@ import (
 //go:generate counterfeiter . Driver
 type Driver interface {
 	Unpack(logger lager.Logger, layerID string, parentIDs []string, layerTar io.Reader) error
-	Bundle(logger lager.Logger, bundleID string, layerIDs []string) (runspec.Spec, error)
+	Bundle(logger lager.Logger, bundleID string, layerIDs []string, diskLimit int64) (runspec.Spec, error)
 	Exists(logger lager.Logger, layerID string) bool
 	Delete(logger lager.Logger, bundleID string) error
 }
@@ -58,6 +58,16 @@ func Run(driver Driver, argv []string, driverFlags []cli.Flag) {
 	app.Commands = []cli.Command{
 		{
 			Name: "create",
+			Flags: []cli.Flag{
+				cli.Int64Flag{
+					Name:  "disk-limit-size-bytes",
+					Usage: "Inclusive disk limit (i.e: includes all layers in the filesystem)",
+				},
+				cli.BoolFlag{
+					Name:  "exclude-image-from-quota",
+					Usage: "Set disk limit to be exclusive (i.e.: excluding image layers)",
+				},
+			},
 			Action: func(ctx *cli.Context) error {
 				rootfsURI, err := url.Parse(ctx.Args()[0])
 				if err != nil {
@@ -65,7 +75,7 @@ func Run(driver Driver, argv []string, driverFlags []cli.Flag) {
 				}
 
 				handle := ctx.Args()[1]
-				runtimeSpec, err := g.Create(handle, rootfsURI)
+				runtimeSpec, err := g.Create(handle, rootfsURI, ctx.Int64("disk-limit-size-bytes"), ctx.Bool("exclude-image-from-quota"))
 				if err != nil {
 					return err
 				}

--- a/grootfakes/fake_driver.go
+++ b/grootfakes/fake_driver.go
@@ -25,12 +25,13 @@ type FakeDriver struct {
 	unpackReturnsOnCall map[int]struct {
 		result1 error
 	}
-	BundleStub        func(logger lager.Logger, bundleID string, layerIDs []string) (runspec.Spec, error)
+	BundleStub        func(logger lager.Logger, bundleID string, layerIDs []string, diskLimit int64) (runspec.Spec, error)
 	bundleMutex       sync.RWMutex
 	bundleArgsForCall []struct {
-		logger   lager.Logger
-		bundleID string
-		layerIDs []string
+		logger    lager.Logger
+		bundleID  string
+		layerIDs  []string
+		diskLimit int64
 	}
 	bundleReturns struct {
 		result1 runspec.Spec
@@ -124,7 +125,7 @@ func (fake *FakeDriver) UnpackReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeDriver) Bundle(logger lager.Logger, bundleID string, layerIDs []string) (runspec.Spec, error) {
+func (fake *FakeDriver) Bundle(logger lager.Logger, bundleID string, layerIDs []string, diskLimit int64) (runspec.Spec, error) {
 	var layerIDsCopy []string
 	if layerIDs != nil {
 		layerIDsCopy = make([]string, len(layerIDs))
@@ -133,14 +134,15 @@ func (fake *FakeDriver) Bundle(logger lager.Logger, bundleID string, layerIDs []
 	fake.bundleMutex.Lock()
 	ret, specificReturn := fake.bundleReturnsOnCall[len(fake.bundleArgsForCall)]
 	fake.bundleArgsForCall = append(fake.bundleArgsForCall, struct {
-		logger   lager.Logger
-		bundleID string
-		layerIDs []string
-	}{logger, bundleID, layerIDsCopy})
-	fake.recordInvocation("Bundle", []interface{}{logger, bundleID, layerIDsCopy})
+		logger    lager.Logger
+		bundleID  string
+		layerIDs  []string
+		diskLimit int64
+	}{logger, bundleID, layerIDsCopy, diskLimit})
+	fake.recordInvocation("Bundle", []interface{}{logger, bundleID, layerIDsCopy, diskLimit})
 	fake.bundleMutex.Unlock()
 	if fake.BundleStub != nil {
-		return fake.BundleStub(logger, bundleID, layerIDs)
+		return fake.BundleStub(logger, bundleID, layerIDs, diskLimit)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -154,10 +156,10 @@ func (fake *FakeDriver) BundleCallCount() int {
 	return len(fake.bundleArgsForCall)
 }
 
-func (fake *FakeDriver) BundleArgsForCall(i int) (lager.Logger, string, []string) {
+func (fake *FakeDriver) BundleArgsForCall(i int) (lager.Logger, string, []string, int64) {
 	fake.bundleMutex.RLock()
 	defer fake.bundleMutex.RUnlock()
-	return fake.bundleArgsForCall[i].logger, fake.bundleArgsForCall[i].bundleID, fake.bundleArgsForCall[i].layerIDs
+	return fake.bundleArgsForCall[i].logger, fake.bundleArgsForCall[i].bundleID, fake.bundleArgsForCall[i].layerIDs, fake.bundleArgsForCall[i].diskLimit
 }
 
 func (fake *FakeDriver) BundleReturns(result1 runspec.Spec, result2 error) {

--- a/imagepuller/image_puller.go
+++ b/imagepuller/image_puller.go
@@ -42,8 +42,9 @@ type VolumeDriver interface {
 }
 
 type Image struct {
-	Image    imgspec.Image
-	ChainIDs []string
+	Image         imgspec.Image
+	ChainIDs      []string
+	BaseImageSize int64
 }
 
 type ImageSpec struct {
@@ -86,8 +87,9 @@ func (p *ImagePuller) Pull(logger lager.Logger, spec ImageSpec) (Image, error) {
 	chainIDs := p.chainIDs(imageInfo.LayerInfos)
 
 	image := Image{
-		Image:    imageInfo.Config,
-		ChainIDs: chainIDs,
+		Image:         imageInfo.Config,
+		ChainIDs:      chainIDs,
+		BaseImageSize: p.layersSize(imageInfo.LayerInfos),
 	}
 	return image, nil
 }

--- a/imagepuller/image_puller_test.go
+++ b/imagepuller/image_puller_test.go
@@ -37,9 +37,9 @@ var _ = Describe("Image Puller", func() {
 		fakeFetcher = new(imagepullerfakes.FakeFetcher)
 		expectedImgDesc = specsv1.Image{Author: "Groot"}
 		layerInfos = []imagepuller.LayerInfo{
-			{BlobID: "i-am-a-layer", ChainID: "layer-111", ParentChainID: ""},
-			{BlobID: "i-am-another-layer", ChainID: "chain-222", ParentChainID: "layer-111"},
-			{BlobID: "i-am-the-last-layer", ChainID: "chain-333", ParentChainID: "chain-222"},
+			{BlobID: "i-am-a-layer", ChainID: "layer-111", ParentChainID: "", Size: 111},
+			{BlobID: "i-am-another-layer", ChainID: "chain-222", ParentChainID: "layer-111", Size: 222},
+			{BlobID: "i-am-the-last-layer", ChainID: "chain-333", ParentChainID: "chain-222", Size: 333},
 		}
 		fakeFetcher.ImageInfoReturns(
 			imagepuller.ImageInfo{
@@ -85,6 +85,14 @@ var _ = Describe("Image Puller", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(image.ChainIDs).To(Equal([]string{"layer-111", "chain-222", "chain-333"}))
+	})
+
+	It("returns the total size of the base image", func() {
+		image, err := imagePuller.Pull(logger, imagepuller.ImageSpec{
+			ImageSrc: imageSrcURL,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(image.BaseImageSize).To(Equal(int64(666)))
 	})
 
 	It("passes the correct parentIDs to Unpack", func() {

--- a/imagepuller/imagepullerfakes/fake_volume_driver.go
+++ b/imagepuller/imagepullerfakes/fake_volume_driver.go
@@ -10,13 +10,13 @@ import (
 )
 
 type FakeVolumeDriver struct {
-	UnpackStub        func(logger lager.Logger, layerID string, parentID []string, layerTar io.Reader) error
+	UnpackStub        func(logger lager.Logger, layerID string, parentIDs []string, layerTar io.Reader) error
 	unpackMutex       sync.RWMutex
 	unpackArgsForCall []struct {
-		logger   lager.Logger
-		layerID  string
-		parentID []string
-		layerTar io.Reader
+		logger    lager.Logger
+		layerID   string
+		parentIDs []string
+		layerTar  io.Reader
 	}
 	unpackReturns struct {
 		result1 error
@@ -40,24 +40,24 @@ type FakeVolumeDriver struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeVolumeDriver) Unpack(logger lager.Logger, layerID string, parentID []string, layerTar io.Reader) error {
-	var parentIDCopy []string
-	if parentID != nil {
-		parentIDCopy = make([]string, len(parentID))
-		copy(parentIDCopy, parentID)
+func (fake *FakeVolumeDriver) Unpack(logger lager.Logger, layerID string, parentIDs []string, layerTar io.Reader) error {
+	var parentIDsCopy []string
+	if parentIDs != nil {
+		parentIDsCopy = make([]string, len(parentIDs))
+		copy(parentIDsCopy, parentIDs)
 	}
 	fake.unpackMutex.Lock()
 	ret, specificReturn := fake.unpackReturnsOnCall[len(fake.unpackArgsForCall)]
 	fake.unpackArgsForCall = append(fake.unpackArgsForCall, struct {
-		logger   lager.Logger
-		layerID  string
-		parentID []string
-		layerTar io.Reader
-	}{logger, layerID, parentIDCopy, layerTar})
-	fake.recordInvocation("Unpack", []interface{}{logger, layerID, parentIDCopy, layerTar})
+		logger    lager.Logger
+		layerID   string
+		parentIDs []string
+		layerTar  io.Reader
+	}{logger, layerID, parentIDsCopy, layerTar})
+	fake.recordInvocation("Unpack", []interface{}{logger, layerID, parentIDsCopy, layerTar})
 	fake.unpackMutex.Unlock()
 	if fake.UnpackStub != nil {
-		return fake.UnpackStub(logger, layerID, parentID, layerTar)
+		return fake.UnpackStub(logger, layerID, parentIDs, layerTar)
 	}
 	if specificReturn {
 		return ret.result1
@@ -74,7 +74,7 @@ func (fake *FakeVolumeDriver) UnpackCallCount() int {
 func (fake *FakeVolumeDriver) UnpackArgsForCall(i int) (lager.Logger, string, []string, io.Reader) {
 	fake.unpackMutex.RLock()
 	defer fake.unpackMutex.RUnlock()
-	return fake.unpackArgsForCall[i].logger, fake.unpackArgsForCall[i].layerID, fake.unpackArgsForCall[i].parentID, fake.unpackArgsForCall[i].layerTar
+	return fake.unpackArgsForCall[i].logger, fake.unpackArgsForCall[i].layerID, fake.unpackArgsForCall[i].parentIDs, fake.unpackArgsForCall[i].layerTar
 }
 
 func (fake *FakeVolumeDriver) UnpackReturns(result1 error) {

--- a/integration/cmd/foot/foot/foot.go
+++ b/integration/cmd/foot/foot/foot.go
@@ -32,7 +32,7 @@ func (t *Foot) Unpack(logger lager.Logger, id string, parentIDs []string, layerT
 	return nil
 }
 
-func (t *Foot) Bundle(logger lager.Logger, id string, layerIDs []string) (specs.Spec, error) {
+func (t *Foot) Bundle(logger lager.Logger, id string, layerIDs []string, diskLimit int64) (specs.Spec, error) {
 	logger.Info("bundle-info")
 	logger.Debug("bundle-debug")
 
@@ -41,7 +41,7 @@ func (t *Foot) Bundle(logger lager.Logger, id string, layerIDs []string) (specs.
 	}
 
 	saveObject([]interface{}{
-		BundleArgs{ID: id, LayerIDs: layerIDs},
+		BundleArgs{ID: id, LayerIDs: layerIDs, DiskLimit: diskLimit},
 	}, t.pathTo(BundleArgsFileName))
 	return BundleRuntimeSpec, nil
 }
@@ -105,8 +105,9 @@ type UnpackArgs struct {
 
 type BundleCalls []BundleArgs
 type BundleArgs struct {
-	ID       string
-	LayerIDs []string
+	ID        string
+	LayerIDs  []string
+	DiskLimit int64
 }
 
 func (t *Foot) pathTo(filename string) string {

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -17,8 +17,10 @@ import (
 
 var _ = Describe("create", func() {
 	var (
-		rootfsURI string
-		handle    = "some-handle"
+		rootfsURI         string
+		handle            = "some-handle"
+		expectedDiskLimit int64
+		createArgs        []string
 	)
 
 	BeforeEach(func() {
@@ -32,6 +34,9 @@ var _ = Describe("create", func() {
 		env = []string{}
 		stdout = new(bytes.Buffer)
 		stderr = new(bytes.Buffer)
+
+		createArgs = []string{}
+		expectedDiskLimit = 0
 	})
 
 	AfterEach(func() {
@@ -39,7 +44,8 @@ var _ = Describe("create", func() {
 	})
 
 	runCreateCmd := func() error {
-		footArgv := []string{"--config", configFilePath, "--driver-store", tempDir, "create", rootfsURI, handle}
+		footArgv := append([]string{"--config", configFilePath, "--driver-store", tempDir, "create"}, createArgs...)
+		footArgv = append(footArgv, rootfsURI, handle)
 		footCmd := exec.Command(footBinPath, footArgv...)
 		footCmd.Stdout = io.MultiWriter(stdout, GinkgoWriter)
 		footCmd.Stderr = io.MultiWriter(stderr, GinkgoWriter)
@@ -60,6 +66,7 @@ var _ = Describe("create", func() {
 			}
 			Expect(bundleArgs[0].ID).To(Equal(handle))
 			Expect(bundleArgs[0].LayerIDs).To(ConsistOf(unpackLayerIds))
+			Expect(bundleArgs[0].DiskLimit).To(Equal(expectedDiskLimit))
 		})
 	}
 
@@ -83,14 +90,38 @@ var _ = Describe("create", func() {
 		})
 
 		Describe("Local images", func() {
+			var imageSize int64
+
 			JustBeforeEach(func() {
-				writeFile(rootfsURI, "a-rootfs")
+				imageContents := "a-rootfs"
+				imageSize = int64(len(imageContents))
+				writeFile(rootfsURI, imageContents)
 				Expect(runCreateCmd()).To(Succeed())
 			})
 
 			Context("when command succeeds", func() {
 				unpackIsSuccessful(runCreateCmd)
 				bundleIsSuccessful(handle)
+			})
+
+			Context("--disk-limit-size-bytes is given", func() {
+				BeforeEach(func() {
+					createArgs = []string{"--disk-limit-size-bytes", "500"}
+					expectedDiskLimit = 500 - imageSize
+				})
+
+				unpackIsSuccessful(runCreateCmd)
+				bundleIsSuccessful(handle)
+
+				Context("--exclude-image-from-quota is given as well", func() {
+					BeforeEach(func() {
+						createArgs = []string{"--disk-limit-size-bytes", "500", "--exclude-image-from-quota"}
+						expectedDiskLimit = 500
+					})
+
+					unpackIsSuccessful(runCreateCmd)
+					bundleIsSuccessful(handle)
+				})
 			})
 
 			It("calls driver.Unpack() with the correct stream", func() {
@@ -121,7 +152,9 @@ var _ = Describe("create", func() {
 		})
 
 		Describe("Remote images", func() {
+			var imageSize int64
 			JustBeforeEach(func() {
+				imageSize = 297
 				rootfsURI = "docker:///cfgarden/three-layers"
 
 				Expect(runCreateCmd()).To(Succeed())
@@ -130,6 +163,26 @@ var _ = Describe("create", func() {
 			Context("when command succeeds", func() {
 				unpackIsSuccessful(runCreateCmd)
 				bundleIsSuccessful(handle)
+			})
+
+			Context("--disk-limit-size-bytes is given", func() {
+				BeforeEach(func() {
+					createArgs = []string{"--disk-limit-size-bytes", "500"}
+					expectedDiskLimit = 500 - imageSize
+				})
+
+				unpackIsSuccessful(runCreateCmd)
+				bundleIsSuccessful(handle)
+
+				Context("--exclude-image-from-quota is given as well", func() {
+					BeforeEach(func() {
+						createArgs = []string{"--disk-limit-size-bytes", "500", "--exclude-image-from-quota"}
+						expectedDiskLimit = 500
+					})
+
+					unpackIsSuccessful(runCreateCmd)
+					bundleIsSuccessful(handle)
+				})
 			})
 
 			Context("when the image has multiple layers", func() {
@@ -171,6 +224,36 @@ var _ = Describe("create", func() {
 
 				It("prints an error", func() {
 					Expect(stdout.String()).To(ContainSubstring(notFoundRuntimeError[runtime.GOOS]))
+				})
+			})
+
+			Context("--disk-limit-size-bytes is negative", func() {
+				BeforeEach(func() {
+					createArgs = []string{"--disk-limit-size-bytes", "-500", "--exclude-image-from-quota"}
+				})
+
+				It("prints an error", func() {
+					Expect(stdout.String()).To(ContainSubstring("invalid disk limit: -500"))
+				})
+			})
+
+			Context("--disk-limit-size-bytes is less than the image size", func() {
+				BeforeEach(func() {
+					createArgs = []string{"--disk-limit-size-bytes", "5"}
+				})
+
+				It("prints an error", func() {
+					Expect(stdout.String()).To(ContainSubstring("pulling image: layers exceed disk quota 8/5 bytes"))
+				})
+			})
+
+			Context("--disk-limit-size-bytes is exactly the image size", func() {
+				BeforeEach(func() {
+					createArgs = []string{"--disk-limit-size-bytes", "8"}
+				})
+
+				It("prints an error", func() {
+					Expect(stdout.String()).To(ContainSubstring("disk limit 8 must be larger than image size 8"))
 				})
 			})
 		})

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,11 +23,9 @@ var _ = Describe("create", func() {
 	)
 
 	BeforeEach(func() {
-		var err error
-		tempDir, err = ioutil.TempDir("", "groot-integration-tests")
-		Expect(err).NotTo(HaveOccurred())
-		configFilePath = filepath.Join(tempDir, "groot-config.yml")
-		rootfsURI = filepath.Join(tempDir, "rootfs.tar")
+		tmpDir = tempDir("", "groot-integration-tests")
+		configFilePath = filepath.Join(tmpDir, "groot-config.yml")
+		rootfsURI = filepath.Join(tmpDir, "rootfs.tar")
 
 		logLevel = ""
 		env = []string{}
@@ -40,11 +37,11 @@ var _ = Describe("create", func() {
 	})
 
 	AfterEach(func() {
-		Expect(os.RemoveAll(tempDir)).To(Succeed())
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 	})
 
 	runCreateCmd := func() error {
-		footArgv := append([]string{"--config", configFilePath, "--driver-store", tempDir, "create"}, createArgs...)
+		footArgv := append([]string{"--config", configFilePath, "--driver-store", tmpDir, "create"}, createArgs...)
 		footArgv = append(footArgv, rootfsURI, handle)
 		footCmd := exec.Command(footBinPath, footArgv...)
 		footCmd.Stdout = io.MultiWriter(stdout, GinkgoWriter)

--- a/integration/delete_test.go
+++ b/integration/delete_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,37 +16,33 @@ import (
 var _ = Describe("groot", func() {
 	Describe("delete", func() {
 		var (
-			handle  = "some-handle"
-			env     []string
-			tempDir string
-			stdout  *bytes.Buffer
+			handle = "some-handle"
+			env    []string
+			stdout *bytes.Buffer
 		)
 
 		argFilePath := func(filename string) string {
-			return filepath.Join(tempDir, filename)
+			return filepath.Join(tmpDir, filename)
 		}
 
 		readTestArgsFile := func(filename string, ptr interface{}) {
-			content, err := ioutil.ReadFile(argFilePath(filename))
-			Expect(err).NotTo(HaveOccurred())
+			content := readFile(argFilePath(filename))
 			Expect(json.Unmarshal(content, ptr)).To(Succeed())
 		}
 
 		BeforeEach(func() {
-			var err error
-			tempDir, err = ioutil.TempDir("", "groot-integration-tests")
-			Expect(err).NotTo(HaveOccurred())
+			tmpDir = tempDir("", "groot-integration-tests")
 
 			env = []string{}
 			stdout = new(bytes.Buffer)
 		})
 
 		AfterEach(func() {
-			Expect(os.RemoveAll(tempDir)).To(Succeed())
+			Expect(os.RemoveAll(tmpDir)).To(Succeed())
 		})
 
 		runFootCmd := func() error {
-			footArgv := []string{"--driver-store", tempDir, "delete", handle}
+			footArgv := []string{"--driver-store", tmpDir, "delete", handle}
 			footCmd := exec.Command(footBinPath, footArgv...)
 			footCmd.Stdout = io.MultiWriter(stdout, GinkgoWriter)
 			footCmd.Env = append(os.Environ(), env...)

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	footBinPath          string
-	tempDir              string
+	tmpDir               string
 	env                  []string
 	logLevel             string
 	configFilePath       string
@@ -49,13 +49,12 @@ func TestIntegration(t *testing.T) {
 }
 
 func readTestArgsFile(filename string, ptr interface{}) {
-	content, err := ioutil.ReadFile(argFilePath(filename))
-	Expect(err).NotTo(HaveOccurred())
+	content := readFile(argFilePath(filename))
 	Expect(json.Unmarshal(content, ptr)).To(Succeed())
 }
 
 func argFilePath(filename string) string {
-	return filepath.Join(tempDir, filename)
+	return filepath.Join(tmpDir, filename)
 }
 
 func unpackIsSuccessful(runFootCmd func() error) {
@@ -182,4 +181,16 @@ func whenUnpackIsUnsuccessful(runFootCmd func() error) {
 
 func writeFile(path, content string) {
 	Expect(ioutil.WriteFile(path, []byte(content), 0600)).To(Succeed())
+}
+
+func tempDir(dir, prefix string) string {
+	name, err := ioutil.TempDir(dir, prefix)
+	Expect(err).NotTo(HaveOccurred())
+	return name
+}
+
+func readFile(filename string) []byte {
+	content, err := ioutil.ReadFile(filename)
+	Expect(err).NotTo(HaveOccurred())
+	return content
 }

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -3,7 +3,6 @@ package integration_test
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,11 +18,9 @@ var _ = Describe("pull", func() {
 	var rootfsURI string
 
 	BeforeEach(func() {
-		var err error
-		tempDir, err = ioutil.TempDir("", "groot-integration-tests")
-		Expect(err).NotTo(HaveOccurred())
-		configFilePath = filepath.Join(tempDir, "groot-config.yml")
-		rootfsURI = filepath.Join(tempDir, "rootfs.tar")
+		tmpDir = tempDir("", "groot-integration-tests")
+		configFilePath = filepath.Join(tmpDir, "groot-config.yml")
+		rootfsURI = filepath.Join(tmpDir, "rootfs.tar")
 
 		logLevel = ""
 		env = []string{}
@@ -32,11 +29,11 @@ var _ = Describe("pull", func() {
 	})
 
 	AfterEach(func() {
-		Expect(os.RemoveAll(tempDir)).To(Succeed())
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 	})
 
 	runPullCmd := func() error {
-		footArgv := []string{"--config", configFilePath, "--driver-store", tempDir, "pull", rootfsURI}
+		footArgv := []string{"--config", configFilePath, "--driver-store", tmpDir, "pull", rootfsURI}
 		footCmd := exec.Command(footBinPath, footArgv...)
 		footCmd.Stdout = io.MultiWriter(stdout, GinkgoWriter)
 		footCmd.Stderr = io.MultiWriter(stderr, GinkgoWriter)


### PR DESCRIPTION
The Image struct returned by the imagePuller now includes the total size
of the base image. This, along with the actual limit and the "exclude image from quota" flag are passed into `Bundle()` 

This is necessary because Windows quotas on a
container volume do not include the size of the base layers on disk -
they are always in addition to that size (e.g. a 200 MB quota on volume
created from a 100 MB image would result in up to 300 MB of disk being
used).
