### PR TITLE
groot should support URI paths without C: for oci

### DIFF
--- a/fetcher/layerfetcher/source/layer_source.go
+++ b/fetcher/layerfetcher/source/layer_source.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -222,7 +223,7 @@ func generateRefString(imageURL *url.URL) string {
 	refString += imageURL.Path
 
 	if runtime.GOOS == "windows" && imageURL.Scheme == "oci" {
-		refString = strings.TrimPrefix(refString, "//")
+		refString = destToWindowsPath(refString)
 	}
 
 	return refString
@@ -339,4 +340,16 @@ func preferedMediaTypes() []string {
 		imgspec.MediaTypeImageManifest,
 		manifestpkg.DockerV2Schema2MediaType,
 	}
+}
+
+func destToWindowsPath(input string) string {
+	input = strings.TrimPrefix(input, "//")
+	vol := filepath.VolumeName(input)
+	if vol == "" {
+		if !strings.HasPrefix(input, "/") {
+			input = filepath.Join("/", input)
+		}
+		input = filepath.Join("C:", input)
+	}
+	return filepath.Clean(input)
 }


### PR DESCRIPTION
Set of valid paths:

 - oci:///var/vcap/packages/windows2016fs
 - oci:///C:/var/vcap/packages/windows2016fs
 - oci:///C:\var\vcap\packages\windows2016fs