### PR TITLE
Let users specify the app version when calling groot.Run()

### DIFF
--- a/groot.go
+++ b/groot.go
@@ -68,7 +68,7 @@ type DockerConfig struct {
 	Password           string
 }
 
-func Run(driver Driver, argv []string, driverFlags []cli.Flag) {
+func Run(driver Driver, argv []string, driverFlags []cli.Flag, version string) {
 	// The `Before` closure sets this. This is ugly, but we don't know the log
 	// level until the CLI framework has parsed the flags.
 	var g *Groot
@@ -77,6 +77,7 @@ func Run(driver Driver, argv []string, driverFlags []cli.Flag) {
 	var conf config
 
 	app := cli.NewApp()
+	app.Version = version
 	app.Usage = "A garden image plugin"
 	app.Flags = append([]cli.Flag{
 		cli.StringFlag{


### PR DESCRIPTION
The signature of [groot.Run()](https://github.com/cloudfoundry/groot/blob/master/groot.go#L65) doesn't let us specify the [App.Version](https://github.com/urfave/cli#version-flag). The flag is automatically enabled by urfave/cli but there is no way to set it to a value.
