### PR TITLE
Fix issue with test script not using new Ginkgo v2 syntax

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -37,5 +37,5 @@ done
   if [ -z ${DOCKER_REGISTRY_USERNAME+x} ]; then
     set_default_groot_env
   fi
-  ginkgo -mod vendor -r -keep-going -fail-on-pending -randomize-all -randomize-suites -p "$@"
+  ginkgo -mod vendor -r -keepGoing -failOnPending -randomizeAllSpecs -randomizeSuites -p "$@"
 )


### PR DESCRIPTION
Old script was using v1 and was not working.