### PR TITLE
cleanup time format property

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,7 +9,6 @@ import (
 
 type config struct {
 	LogLevel           string   `yaml:"log_level"`
-	LogFormat          string   `yaml:"log_format"`
 	InsecureRegistries []string `yaml:"insecure_registries"`
 }
 
@@ -39,9 +38,6 @@ func parseConfig(configFilePath string) (conf config, err error) {
 func applyDefaults(conf config) config {
 	if conf.LogLevel == "" {
 		conf.LogLevel = "info"
-	}
-	if conf.LogFormat == "" {
-		conf.LogFormat = "rfc3339"
 	}
 	return conf
 }

--- a/groot.go
+++ b/groot.go
@@ -198,7 +198,7 @@ func Run(driver Driver, argv []string, driverFlags []cli.Flag, version string) {
 			return silentError(err)
 		}
 
-		logger, err := newLogger(conf.LogLevel, conf.LogFormat)
+		logger, err := newLogger(conf.LogLevel)
 		if err != nil {
 			return err
 		}
@@ -247,7 +247,7 @@ func shouldSkipImageQuotaValidation(excludeImageFromQuota bool, diskLimitSizeByt
 	return excludeImageFromQuota || diskLimitSizeBytes == 0
 }
 
-func newLogger(logLevelStr, logFormat string) (lager.Logger, error) {
+func newLogger(logLevelStr string) (lager.Logger, error) {
 	logLevels := map[string]lager.LogLevel{
 		"debug": lager.DEBUG,
 		"info":  lager.INFO,
@@ -260,15 +260,7 @@ func newLogger(logLevelStr, logFormat string) (lager.Logger, error) {
 		return nil, fmt.Errorf("invalid log level: %s", logLevelStr)
 	}
 
-	var sink lager.Sink
-	switch logFormat {
-	case "rfc3339":
-		sink = lager.NewPrettySink(os.Stderr, logLevel)
-	case "epoch":
-		sink = lager.NewWriterSink(os.Stderr, logLevel)
-	default:
-		return nil, fmt.Errorf("invalid log format: %s", logFormat)
-	}
+	sink := lager.NewPrettySink(os.Stderr, logLevel)
 
 	logger := lager.NewLogger("groot")
 	logger.RegisterSink(sink)

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -314,15 +314,6 @@ var _ = Describe("create", func() {
 				expectErrorOutput("lol")
 			})
 		})
-		Context("when the specified log format is invalid", func() {
-			BeforeEach(func() {
-				writeFile(configFilePath, "log_format: lol")
-			})
-
-			It("prints an error", func() {
-				expectErrorOutput("lol")
-			})
-		})
 
 		Context("when driver.Bundle() returns an error", func() {
 			BeforeEach(func() {

--- a/integration/pull_test.go
+++ b/integration/pull_test.go
@@ -156,15 +156,6 @@ var _ = Describe("pull", func() {
 				expectErrorOutput("lol")
 			})
 		})
-		Context("when the specified log format is invalid", func() {
-			BeforeEach(func() {
-				writeFile(configFilePath, "log_format: lol")
-			})
-
-			It("prints an error", func() {
-				expectErrorOutput("lol")
-			})
-		})
 
 		Context("when the rootfs URI is not a file", func() {
 			BeforeEach(func() {


### PR DESCRIPTION
- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
cleanup time format property
```

Before:
{"timestamp":"1750436098.703817368","source":"groot","message":"groot.pull.image-pulling.build-layer.unpack-finished","log_level":1,"data":{"blobID":"sha256:7d47e
aba26a3aa24d17d5d8b88db4d2e14cca413650b045b5db8d370e738d6b8","chainID":"d6f0bbbfc250055e8eb9786268a29df9ef6572c31a68d7548a9bcd84f5bc1d18","parentChainID":"62d5797
5ea77c44a26a568269c4a371c00dc7ab307aca5b52b6831f1d987fc7d","session":"1.1.43","spec":{"DiskLimit":0,"ExcludeImageFromQuota":false}}}                              
{"timestamp":"1750436098.705716133","source":"groot","message":"groot.pull.image-pulling.ending","log_level":1,"data":{"session":"1.1","spec":{"DiskLimit":0,"Excl
udeImageFromQuota":false}}}                                                                                                                                       
                                                                                                                                                                  
bosh_249a99a507474d3@VM-D9E09CF9-811 C:\var\vcap\sys\log\groot>

After:
{"timestamp":"2025-06-20T16:51:29.101705700Z","level":"info","source":"groot","message":"groot.pull.image-pulling.ending","data":{"session":"1.1","spec":{"DiskLim
it":0,"ExcludeImageFromQuota":false}}}                                                                                                                            
                                                                                                                                                                  
bosh_cbd52e4c606a47a@VM-D9E09CF9-811 C:\var\vcap\sys\log\groot>   
```


Backward Compatibility
---------------
Breaking Change? **No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
